### PR TITLE
Compatibility patches for FreeTDS

### DIFF
--- a/src/cmd_bcp.c
+++ b/src/cmd_bcp.c
@@ -745,7 +745,7 @@ int cmd_bcp( argc, argv )
         goto return_fail;
     }
 
-#if defined(CS_SERVERADDR) && defined(CS_TDS_50)
+#if defined(CS_SERVERADDR) && !defined(SQSH_FREETDS)
     if ( server != NULL && (cp = strchr(server, ':')) != NULL )
     {
         char  *cp2;

--- a/src/cmd_connect.c
+++ b/src/cmd_connect.c
@@ -1910,7 +1910,9 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
 
 #if defined(CS_SEC_NETWORKAUTH)
 
+#if defined(CS_SEC_MECHANISM)
     CS_CHAR buf[CS_MAX_CHAR+1];
+#endif
     CS_INT  buflen;
     CS_INT  i;
     CS_BOOL OptSupported;
@@ -1920,14 +1922,30 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
        * CS_SEC_NETWORKAUTH must be the first entry
       */
     { CS_SEC_NETWORKAUTH,    'u', "Network user authentication (unified login)" },
+#if defined(CS_SEC_CHANBIND)
     { CS_SEC_CHANBIND,       'b', "Channel binding" },
+#endif
+#if defined(CS_SEC_CONFIDENTIALITY)
     { CS_SEC_CONFIDENTIALITY,'c', "Data confidentiality" },
+#endif
+#if defined(CS_SEC_DELEGATION)
     { CS_SEC_DELEGATION,     'd', "Credentials delegation" },
+#endif
+#if defined(CS_SEC_INTEGRITY)
     { CS_SEC_INTEGRITY,      'i', "Data integrity" },
+#endif
+#if defined(CS_SEC_MUTUALAUTH)
     { CS_SEC_MUTUALAUTH,     'm', "Mutual client/server authentication" },
+#endif
+#if defined(CS_SEC_DATAORIGIN)
     { CS_SEC_DATAORIGIN,     'o', "Data origin stamping" },
+#endif
+#if defined(CS_SEC_DETECTSEQ)
     { CS_SEC_DETECTSEQ,      'q', "Data out-of-sequence detection" },
+#endif
+#if defined(CS_SEC_DETECTREPLAY)
     { CS_SEC_DETECTREPLAY,   'r', "Data replay detection" },
+#endif
     { CS_UNUSED,             ' ', "" }
     };
 
@@ -1956,6 +1974,7 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
         DBG(sqsh_debug(DEBUG_ERROR, "SetNetAuth: Succesfully set principal %s.\n", principal);)
     }
 
+#if defined(CS_SEC_KEYTAB)
     /*
      * Set optional keytab file for DCE network authentication.
      */
@@ -1974,7 +1993,9 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
         }
         DBG(sqsh_debug(DEBUG_ERROR, "SetNetAuth: Succesfully set keytab %s.\n", keytab_file);)
     }
+#endif
 
+#if defined(CS_SEC_MECHANISM)
     /*
      * Set the security mechanism.
      * Note: If you do not supply a mechanism, or use "default", the first available
@@ -1995,6 +2016,7 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
         }
         DBG(sqsh_debug(DEBUG_ERROR, "SetNetAuth: Succesfully set secmech %s.\n", secmech);)
     }
+#endif
 
     /*
      * Always set the CS_SEC_NETWORKAUTH option. (Option defined in nss[0]).
@@ -2008,6 +2030,7 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
     }
     DBG(sqsh_debug(DEBUG_ERROR, "SetNetAuth: Succesfully enabled option %s.\n", nss[0].name);)
 
+#if defined(CS_SEC_MECHANISM)
     /*
      * Request for the secmech actually in use.
     */
@@ -2024,6 +2047,7 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
     }
     DBG(sqsh_debug(DEBUG_ERROR, "SetNetAuth: Succesfully obtained secmech name %s.\n", buf);)
     env_put( g_env, "secmech", buf, ENV_F_TRAN );
+#endif
 
     /*
      * Loop through the list of all other available security options
@@ -2110,6 +2134,7 @@ static CS_RETCODE ShowNetAuthCredExp (conn, cmdname)
 
     if (NETWORKAUTH == CS_TRUE)
     {
+#if defined(CS_SEC_CREDTIMEOUT)
         /*
          * If we use network authentication, then determine the credential timeout period.
         */
@@ -2165,6 +2190,7 @@ static CS_RETCODE ShowNetAuthCredExp (conn, cmdname)
                 fprintf (stdout, "%s: Network Authenticated session expires at: %s (%d secs)\n",
                              cmdname, dttm, (int) CredTimeOut );
         }
+#endif
     }
     else
         fprintf (stdout, "%s: No Network Authenticated session active\n", cmdname );

--- a/src/cmd_connect.c
+++ b/src/cmd_connect.c
@@ -50,12 +50,21 @@ USE(RCS_Id)
  * sqsh-3.0: Define FreeTDS enumerated values to prevent compile errors
  * when using different versions of FreeTDS.
 */
+#if !defined(CS_TDS_70)
 #define CS_TDS_70 7365
+#endif
+#if !defined(CS_TDS_71)
 #define CS_TDS_71 7366
+#endif
+#if !defined(CS_TDS_72)
 #define CS_TDS_72 7367
+#endif
+#if !defined(CS_TDS_73)
 #define CS_TDS_73 7368
+#endif
+#if !defined(CS_TDS_74)
 #define CS_TDS_74 7369
-#define CS_TDS_80 CS_TDS_71
+#endif
 
 /*
  * sqsh-2.1.6 - Structure for Network Security Options
@@ -871,7 +880,7 @@ int cmd_connect( argc, argv )
             version = CS_TDS_495;
         else if (strcmp(tds_version, "5.0") == 0)
             version = CS_TDS_50;
-#if !defined(CS_TDS_50)
+#if defined(SQSH_FREETDS)
         /* Then we use freetds which uses enum instead of defines */
         else if (strcmp(tds_version, "7.0") == 0)
             version = CS_TDS_70;
@@ -883,8 +892,6 @@ int cmd_connect( argc, argv )
             version = CS_TDS_73;
         else if (strcmp(tds_version, "7.4") == 0)
             version = CS_TDS_74;
-        else if (strcmp(tds_version, "8.0") == 0)
-            version = CS_TDS_80;
 #endif
         else version = CS_TDS_50; /* default version */
 
@@ -1016,7 +1023,7 @@ int cmd_connect( argc, argv )
      * OpenClient supports an optional filter that can be specified as third
      * parameter like host:port:filter. Filters are defined in libtcl.cfg.
      */
-#if defined(CS_SERVERADDR) && defined(CS_TDS_50)
+#if defined(CS_SERVERADDR) && !defined(SQSH_FREETDS)
     if ( server != NULL && (cp = strchr(server, ':')) != NULL )
     {
         char  *cp2;
@@ -1277,7 +1284,7 @@ int cmd_connect( argc, argv )
                 case CS_TDS_50:
                     env_set( g_env, "tds_version", "5.0" );
                     break;
-#if !defined(CS_TDS_50)
+#if defined(SQSH_FREETDS)
                 case CS_TDS_70:
                     env_set( g_env, "tds_version", "7.0" );
                     break;
@@ -1825,7 +1832,7 @@ static CS_RETCODE syb_client_cb ( ctx, con, msg )
     if (sg_login == False)
     {
         env_get( g_env, "DSQUERY", &server ) ;
-#if defined(CS_TDS_50)
+#if defined(SQSH_FREETDS)
         if (CS_SEVERITY(msg->msgnumber) >= CS_SV_COMM_FAIL ||
             ctx == NULL || con == NULL)
 #else

--- a/src/cmd_connect.c
+++ b/src/cmd_connect.c
@@ -63,7 +63,7 @@ USE(RCS_Id)
 typedef struct _NetSecService {
     CS_INT  service;
     CS_CHAR optchar;
-    CS_CHAR *name;
+    const CS_CHAR *name;
 } NET_SEC_SERVICE;
 
 /*
@@ -1908,7 +1908,7 @@ static CS_RETCODE SetNetAuth (conn, principal, keytab_file, secmech, req_options
     CS_INT  i;
     CS_BOOL OptSupported;
 
-    NET_SEC_SERVICE nss[] = {
+    static const NET_SEC_SERVICE nss[] = {
       /*
        * CS_SEC_NETWORKAUTH must be the first entry
       */

--- a/src/sqsh_global.h
+++ b/src/sqsh_global.h
@@ -174,4 +174,14 @@ extern int         g_interactive;
 extern FILE       *g_p2f_fp; /* Print to file filepointer */
 extern int         g_p2fc;   /* Print to file count */
 
+#if !defined(CS_NULLDATA)
+#error cspublic.h not included!
+#endif
+
+/* newer FreeTDS versions defines CS_TDS_72, old ones use enumeration but not defines */
+#undef SQSH_FREETDS
+#if defined(CS_TDS_72) || !defined(CS_TDS_50)
+#define SQSH_FREETDS 1
+#endif
+
 #endif


### PR DESCRIPTION
Some definitions are different between Sybase and FreeTDS.
Specifically:
 - some security options are not defined;
 - `CS_TDS_xx` preprocessor macros are defined in some versions but not all.

See commits for details.